### PR TITLE
DPI-2942 Package parcoords in nix

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,16 @@
+{ pkgs ? import <nixpkgs> {}, displayrUtils }:
+
+pkgs.rPackages.buildRPackage {
+  name = "parcoords";
+  version = displayrUtils.extractRVersion (builtins.readFile ./DESCRIPTION); 
+  src = ./.;
+  description = ''
+    Create interactive parallel coordinates charts with this htmlwidget
+    wrapper for d3.js \href{http://syntagmatic.github.io/parallel-coordinates/}
+    {parallel-coordinates}.
+  '';
+  propagatedBuildInputs = with pkgs.rPackages; [ 
+    crosstalk
+    htmlwidgets
+  ];
+}


### PR DESCRIPTION
As part of the R Server CI/CD uplift, this task is to package parcoords in Nix to make R server CI/CD more reliable and reproducible. To build it, see https://github.com/Displayr/NixR